### PR TITLE
Disqus and other enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,5 @@ Features
 Non features (not planned)
 --------------------------
 
-- Comments. Would need a CAPTCHA or another antispam mechanism. Comments are handled through twitter, with a Twitter button
 
 Read the CHANGELOG section of the script header for more updates

--- a/bb.sh
+++ b/bb.sh
@@ -15,7 +15,7 @@
 # Basically it asks the user to create a text file, then converts it into a .html file
 # and then rebuilds the index.html and feed.rss.
 #
-# Comments are not supported.
+# Comments are supported via external service (Disqus).
 #
 # This script is standalone, it doesn't require any other file to run
 #
@@ -60,6 +60,8 @@
 #
 #########################################################################################
 #
+# 1.6.1    'date' fix when hours are 1 digit.
+# 1.6.0    Disqus comments. External configuration file. Check of 'date' command version.
 # 1.5.1    Misc bugfixes and parameter checks
 # 1.5      Durad Radojicic refactored some code and added flexibility and i18n
 # 1.4.2    Now issues are handled at Github
@@ -93,7 +95,7 @@ global_variables() {
     echo Loading inline configuration
 
     global_software_name="BashBlog"
-    global_software_version="1.6.0"
+    global_software_version="1.6.1"
 
     # Blog title
     global_title="My fancy blog"


### PR DESCRIPTION
- Disqus support: Just edit the variables global_disqus and global_disqus_username to enable comments. Needs a Disqus account.
- (Optionally) Reads configuration from an external file. I made this so it's easier to merge code from others without rewriting options in bb.sh. You can also mantain different blogs in the same machine. Copy the  configuration variables to ".config" or set another path for the file.
- It detects if you're using a BSD version of date, and tries to use gdate in that case.
- Changed 
  `date -r $1 +'%Y%m%d%k%M'` to 
  `date -r $1 +'%Y%m%d%H%M'`. 
  It produced an output with spaces when hours where under 10 and later touch complained about wrong timestamps.
