### PR TITLE
Stop Disqus "Comemnts?" link with no username

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -305,7 +305,7 @@ edit() {
 twitter() {
     [[ -z "$global_twitter_username" ]] && return
 
-    if [[ "$global_disqus_username" ]]; then
+    if [[ -z "$global_disqus_username" ]]; then
         echo "<p id='twitter'>$template_comments&nbsp;"
     else
         echo "<p id='twitter'><a href=\"$1#disqus_thread\">$template_comments</a> &nbsp;"


### PR DESCRIPTION
The twitter() method wasn't checking for an empty string for
global_disqus_username, so it would always generate the anchor tag for
the Disqus comments, even if global_disqus_username was an empty
string.  Now the '-z' flag has been added to check for the empty string
correctly.
