### PR TITLE
Don't process header/footer files as blog entries

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -712,7 +712,7 @@ rebuild_all_entries() {
     echo -n "Rebuilding all entries "
 
     for i in *.html; do # no need to sort
-        if [[ "$i" == "$index_file" ]] || [[ "$i" == "$archive_index" ]]; then continue; fi
+        if [[ "$i" == "$index_file" ]] || [[ "$i" == "$archive_index" ]] || [[ "$i" == "$footer_file" ]] || [[ "$i" == "$header_file" ]]; then continue; fi
         contentfile=".tmp.$RANDOM"
         while [ -f "$contentfile" ]; do contentfile=".tmp.$RANDOM"; done
 


### PR DESCRIPTION
rebuild_all_entries wasn't checking if the file in question being
processed was a header or footer file that could be specified in the
configuration.  Now it checks and skips them if they exist [like the
index and archive file(s)].
