### PR TITLE
Don't add disqus comments on *all* "index" pages (including tag pages)

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -536,10 +536,8 @@ create_html_page() {
 
     echo '</div>' >> "$filename" # content
 
-    # Add disqus commments except for index and all_posts pages
-    if [[ ${filename%.*.*} != "index" && ${filename%.*.*} != "all_posts" ]]; then
-    	disqus_body >> "$filename"
-    fi
+    # Add disqus commments except for index pages
+    "$index" == "no" && disqus_body >> "$filename"
     # page footer
     cat .footer.html >> "$filename"
     # close divs


### PR DESCRIPTION
Spotted it at @Puuhinen's blog: disqus comments were added at tag pages. I believe it wasn't intentional (but feel free to correct me, since my site doesn't have any comments at all).

Let's use "$index" instead - it's the third parameter to `create_html_page()` function and is "yes" only when making pages for individual blog posts.
