### PR TITLE
Auto detect markup binary named "markup"

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -144,6 +144,9 @@ global_variables() {
     # Markdown location. Trying to autodetect by default.
     # The invocation must support the signature 'markdown_bin in.md > out.html'
     markdown_bin="$(which Markdown.pl)"
+
+		# look for markdown under name "markdown", e.g. that is on Debian:
+		[[ -z "$markdown_bin" ]] && markdown_bin="$(which markdown)"
 }
 
 # Check for the validity of some variables


### PR DESCRIPTION
then you just need apt-get install markup on debian (tested on debian 7), was not working for Markup.pl binary