### PR TITLE
Update the "not abandoned by" date

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Features
 - Support for tags/categories
 - Support for Markdown, Disqus comments, Twitter, Feedburner, Google Analytics.
 - GNU/Linux, BSD and OSX compatible out of the box (no need for GNU `coreutils` on a Mac)
-- The project isn't abandoned as of 2014. New features and bugfixes added regularly.
+- The project isn't abandoned as of 2015. New features and bugfixes added regularly.
 - Everything stored in a single 700-line bash script, how cool is that?! ;) 
 
 


### PR DESCRIPTION
The README date stamp for "not abandoned by" pulled forward to 2015.