### PR TITLE
Some more optimizations

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -220,7 +220,7 @@ disqus_body() {
     echo '<div id="disqus_thread"></div>
             <script type="text/javascript">
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-               var disqus_shortname = '\'$global_disqus_username\''; // required: replace example with your forum shortname
+               var disqus_shortname = '"'$global_disqus_username'"'; // required: replace example with your forum shortname
 
             /* * * DONT EDIT BELOW THIS LINE * * */
             (function() {
@@ -238,7 +238,7 @@ disqus_footer() {
     [[ -z $global_disqus_username ]] && return
     echo '<script type="text/javascript">
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-        var disqus_shortname = '\'$global_disqus_username\''; // required: replace example with your forum shortname
+        var disqus_shortname = '"'$global_disqus_username'"'; // required: replace example with your forum shortname
 
         /* * * DONT EDIT BELOW THIS LINE * * */
         (function () {

--- a/bb.sh
+++ b/bb.sh
@@ -923,7 +923,7 @@ create_includes() {
         echo '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">'
         echo '<html xmlns="http://www.w3.org/1999/xhtml"><head>'
         echo '<meta http-equiv="Content-type" content="text/html;charset=UTF-8" />'
-        echo '<meta name="viewport" content="width=device-width, initial-scale=1.0">'
+        echo '<meta name="viewport" content="width=device-width, initial-scale=1.0" />'
         printf '<link rel="stylesheet" href="%s" type="text/css" />\n' "${css_include[@]}"
         if [[ -z $global_feedburner ]]; then
             echo "<link rel=\"alternate\" type=\"application/rss+xml\" title=\"$template_subscribe_browser_button\" href=\"$blog_feed\" />"

--- a/bb.sh
+++ b/bb.sh
@@ -144,7 +144,7 @@ global_variables() {
 
     # Markdown location. Trying to autodetect by default.
     # The invocation must support the signature 'markdown_bin in.md > out.html'
-    markdown_bin=$(command -v Markdown.pl || command -v markdown)
+    markdown_bin=$(which Markdown.pl || which markdown)
 }
 
 # Check for the validity of some variables
@@ -161,23 +161,8 @@ global_variables_check() {
 
 # Test if the markdown script is working correctly
 test_markdown() {
-    [[ -z $markdown_bin ]] && return 1
-    command -v diff >/dev/null || return 1
-
-    in=/tmp/md-in-${RANDOM}.md
-    out=/tmp/md-out-${RANDOM}.html
-    good=/tmp/md-good-${RANDOM}.html
-    echo -e "line 1\n\nline 2" > "$in"
-    echo -e "<p>line 1</p>\n\n<p>line 2</p>" > "$good"
-    "$markdown_bin" "$in" > "$out" 2> /dev/null
-    diff $good $out &> /dev/null # output is irrelevant, we'll check $?
-    if (($? != 0)); then
-        rm -f "$in" "$good" "$out"
-        return 1
-    fi
-    
-    rm -f "$in" "$good" "$out"
-    return 0
+    [[ -n $markdown_bin ]] &&
+        [[ $("$markdown_bin" <<< $'line 1\n\nline 2') == $'<p>line 1</p>\n\n<p>line 2</p>' ]]
 }
 
 

--- a/bb.sh
+++ b/bb.sh
@@ -945,7 +945,7 @@ delete_includes() {
 create_css() {
     # To avoid overwriting manual changes. However it is recommended that
     # this function is modified if the user changes the blog.css file
-    [[ -n $css_include ]] && return || css_include=('main.css' 'blog.css')
+    (( ${#css_include[@]} > 0 )) && return || css_include=('main.css' 'blog.css')
     if [[ ! -f blog.css ]]; then 
         # blog.css directives will be loaded after main.css and thus will prevail
         echo '#title{font-size: x-large;}
@@ -1118,7 +1118,7 @@ do_main() {
     # Test for existing html files
     if ls ./*.html &> /dev/null; then
         # We're going to back up just in case
-        tar cfz ".backup.tar.gz" *.html &&
+        tar -c -z -f ".backup.tar.gz" -- *.html &&
             chmod 600 ".backup.tar.gz"
     elif [[ $1 == rebuild ]]; then
         echo "Can't find any html files, nothing to rebuild"


### PR DESCRIPTION
Here are a few more tweaks:
- The test_markdown() function could be drastically simplified
- Bugfix: an XHTML meta tag wasn't self-closed
- Performance optimizations: replace uses of echo ... | cut ... | sed ... with bash parameter substitutions
- More performance optimization by directly using ${filename#./} instead of forking command substitution subshells to call clean_filename()