### PR TITLE
More code refactoring. Limit word splitting and disable globbing by default.

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -770,8 +770,7 @@ tags_in_post() {
     sed -n "/^<p>$template_tags_line_header/ {
                 s/^<p>$template_tags_line_header[[:blank:]]*//
                 s/[[:blank:]]*<[^>]*>[[:blank:]]*//g
-                s/[[:blank:]]*,[[:blank:]]*/,/g
-                s/,\+/\\$newline/g
+                s/[[:blank:]]*,[[:blank:]]*/\\$newline/g
                 p
             }" "$1"
 }


### PR DESCRIPTION
- Do word splitting (IFS) on newline only, and use the newline character `$'\n'` as the separator for everything. Disable globbing (pathname expansion of `*`, `?`, etc.) by default. This makes the code more resilient against common bash snags with unquoted variables. However, some minor changes in coding technique are needed; see the comments.
- With these changes and related adaptations, bashblog should now "just work" with file names and tags containing spaces and other odd characters (i.e. with an empty `$convert_filter`). The default `$convert_filter` is not changed, however.
- Fix bugs in `bb.sh edit -n`.
- Make tags_in_post() work with BSD 'sed'.