### PR TITLE
Fix BSD stat timestamp during rebuild

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -283,7 +283,7 @@ get_html_file_content() {
 edit() {
     [[ ! -f "${1%%.*}.html" ]] && echo "Can't edit post "${1%%.*}.html", did you mean to use \"bb.sh post <draft_file>\"?" && exit -1
     # Original post timestamp
-    edit_timestamp=$(LC_ALL=C date -r "${1%%.*}.html" +"$date_format_full" )
+    edit_timestamp=$(LC_ALL=$date_locale date -r "${1%%.*}.html" +"$date_format_full" )
     touch_timestamp=$(LC_ALL=C date -r "${1%%.*}.html" +"$date_format_timestamp")
     tags_before=$(tags_in_post "${1%%.*}.html")
     if [[ $2 == full ]]; then

--- a/bb.sh
+++ b/bb.sh
@@ -1096,7 +1096,7 @@ date_version_detect() {
                 if [[ $1 == -r ]]; then
                     # Fall back to using stat for 'date -r'
                     format=${3//+/}
-                    stat -f "%Sm" -t "$format" "$2"
+                    date -j -f "$date_format_timestamp" `stat -f "%Sm" -t "$date_format_timestamp" "$2"` "$3"
                 elif [[ $2 == --date* ]]; then
                     # convert between dates using BSD date syntax
                     command date -j -f "$date_format_full" "${2#--date=}" "$1" 


### PR DESCRIPTION
I am running bashblog on an OS X machine using vanilla BSD commands and a `US` locale. However, for bashblog I've set `LC_ALL` to `de_AT` to blog in German.

This causes a `date` error during rebuild:

    $ ./bashblog/bb.sh edit foo.md
    Failed conversion of ``Tue, 14 Feb 2017 22:08:14 +0100'' using format ``%a, %d %b %Y %H:%M:%S %z''
    date: illegal time format
    usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ...
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
    Failed conversion of ``Tue, 14 Feb 2017 22:08:14 +0100'' using format ``%a, %d %b %Y %H:%M:%S %z''
    date: illegal time format
    usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ...
             [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]

That's because BSD `stat` is used as replacement for `date -r` calls, but BSD `stat` does not honour the LC_ALL variable. It always yields timestamps in the system locale. 

For example:

    $ LC_ALL=de_AT stat -f%Sm ~/Documents/
    Dec 31 12:08:16 2016

shows December as `Dec` where it should display as `Dez`.

I suggest to reformat BSD stat output using bashblog's timestamp format, e.g.

    $ stat -f%Sm -t%Y%m%d%H%M.%S ~/Documents/
    201612311208.16
    
    $ LC_ALL=de_AT date -j -f "%Y%m%d%H%M.%S" 201612311208.16
    Sa 31 Dez 2016 12:08:16 CET

This patch also changes `edit_timestamp` locale from `C` to `LC_ALL` to make sure it is parsed correctly in the user-defined locale.

I haven't been able to test this fix on other systems.

