### PR TITLE
add option to trash post

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -623,6 +623,17 @@ EOF
             echo "Saved your draft as '$draft'"
             exit
         fi
+        
+        if [[ $post_status == t || $post_status == T ]]; then
+            echo "Are you sure to trash the post? It will not be saved anywhere." 
+            echo "If and only if you are sure to trash this post, type \"YES\""
+            read -r really_trash
+            if [[ $really_trash == 'YES' ]]; then
+                delete_includes
+                rm "$filename"
+                rm "$TMPFILE"
+            fi
+        fi
     done
 
     if [[ $fmt == md && -n $save_markdown ]]; then


### PR DESCRIPTION
fix #120 
Sorry if I took some joy from you but I just started to like the feeling created PRs give me :)
When needed to comply with git-support it will be one line:
line 635: ```[[ $git_repo == 'true' && -n $commit_message ]] git commit -m"$comit_message" && [[ $git_push_on_commit == 'true' ]] && git push```