### PR TITLE
Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Features
 - Support for tags/categories
 - Support for Markdown, Disqus comments, Twitter, Feedburner, Google Analytics.
 - The project is still maintained as of 2016. Bugs are fixed, and new features are considered (see "Contributing")
+- Optional powerful plugin system.
+  Drop your plugins into a directory called plugins, or for system wide, /usr/share/bashblog/plugins.
 - Everything stored in a single ~1k lines bash script, how cool is that?! ;) 
 
 

--- a/bb.sh
+++ b/bb.sh
@@ -27,9 +27,9 @@ global_variables() {
     # Editor set to environment or nano if none set.
     EDITOR="${EDITOR:-nano}"
     # Blog title
-    global_title="My fancy blog"
+    global_title="My blog"
     # The typical subtitle for each blog
-    global_description="A blog about turtles and carrots"
+    global_description=" blog powered by ${software_name^}"
     # The public base URL for this blog
     global_url="http://example.com/blog"
 
@@ -141,7 +141,7 @@ global_variables() {
     template_twitter_comment="&lt;Type your comment here but please leave the URL so that other people can follow the comments&gt;"
     
     # The locale to use for the dates displayed on screen
-    date_format="%B %d, %Y"
+    date_format="%A, %B %d, %Y"
     date_locale="C"
     date_inpost="bashblog_timestamp"
     # Don't change these dates

--- a/bb.sh
+++ b/bb.sh
@@ -29,7 +29,7 @@ global_variables() {
     # Blog title
     global_title="My blog"
     # The typical subtitle for each blog
-    global_description=" blog powered by ${global_software_name^}"
+    global_description=" blog powered by $(bash --version | head -1 | cut -d '-' -f1)"
     # The public base URL for this blog
     global_url="http://example.com/blog"
 

--- a/bb.sh
+++ b/bb.sh
@@ -29,7 +29,7 @@ global_variables() {
     # Blog title
     global_title="My blog"
     # The typical subtitle for each blog
-    global_description=" blog powered by ${software_name^}"
+    global_description=" blog powered by ${global_software_name^}"
     # The public base URL for this blog
     global_url="http://example.com/blog"
 

--- a/bb.sh
+++ b/bb.sh
@@ -35,8 +35,8 @@ global_variables() {
 
     # Your name
     global_author="John Smith"
-    # You can use twitter or facebook or anything for global_author_url
-    global_author_url="http://twitter.com/example" 
+    # You can use GNU Social or Mastodon or anything for global_author_url
+    global_author_url="https://2mb.social/example" 
     # Your email
     global_email="john@smith.com"
 
@@ -166,7 +166,7 @@ global_variables() {
     markdown_bin="$(command -v markdown || echo "")"
 EOF
     sed -i 's/^ *//g' "$global_config"
-    echo "configuration file \"$global_config\" created. Please edit it to customize settings to your liking." | fold -s
+    echo "configuration file \"$global_config\" created. Please edit it to customize settings to your liking, then run $0 again." | fold -s
     exit 0
 }
 


### PR DESCRIPTION
This is a way for people to write and use plugins. Plugins are sourced into the program itself, so everything is available to them. the call to call_plugins could probably be added in a few more places, but this is a good starting point.

Plugins can be added in a subdirectory called plugins, or system wide in /usr/share/bashblog/plugins. I can write more information for the readme, but basically each of them can be in a file, and they are each written as a series of functions. For example, this plugin will show what you were listening to as you wrote the current post:

```plugin_pre_edit_composed() {
    [[ -z "$1" ]] && return
    sed -i '/Tags: keep-this-tag-format, tags-are-optional, beware-with-underscores-in-markdown, example/d' "$1"
    echo -n "### Composed to the sound of " >> "$1"
    playerctl metadata -f '{{artist}} - {{album}} - {{title}}' >> "$1"
    echo -e "\nTags: keep-this-tag-format, tags-are-optional, beware-with-underscores-in-markdown, example" >> "$1"
}
```

So, each plugin must start with the keyword plugin_ followed by where it's called, in this case pre_edit, and then should have a unique identifier, _composed. I think this will add a whole lot more flexibility to an already powerful system, and the lines of code it took to do it were minimal.