### PR TITLE
Remove .html extension from list of tags in terminal

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -869,7 +869,7 @@ list_tags() {
         [[ -f "$i" ]] || break
         nposts=$(grep -c "<\!-- text begin -->" "$i")
         tagname=${i#"$prefix_tags"}
-        tagname=${tagname#.html}
+        tagname=${tagname%.html}
         ((nposts > 1)) && word=$template_tags_posts || word=$template_tags_posts_singular
         line="$tagname # $nposts # $word"
         lines+=$line\\n


### PR DESCRIPTION
I realized the list_tags() had a typo, it is using a `#` instead of `%`, so it tries to remove the .html from the beginning of the `tagname` variable.

before

> ./bb.sh tags
beware-with-underscores-in-markdown.html    1    post
example.html                                1    post
keep-this-tag-format.html                   1    post
tags-are-optional.html                      1    post

after

> ./bb.sh tags
beware-with-underscores-in-markdown    1    post
example                                1    post
keep-this-tag-format                   1    post
tags-are-optional                      1    post

I think this doesn't conflict with anything else.

Cheers!