### PR TITLE
Generate Sitemap

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -913,8 +913,8 @@ make_sitemap() {
     while [[ -f $blog_sitemap ]]; do sitemapfile=$blog_sitemap.$RANDOM; done
 
     {
-        echo "<?xml version="1.0" encoding="UTF-8"?>"
-        echo "<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">"
+        echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        echo "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
         echo -n "." 1>&3
         while IFS='' read -r i; do
             echo -n "." 1>&3


### PR DESCRIPTION
Added make_sitemap function to help with the blog SEO

- sitemap file name can be changed by change the `global_variable` `blog_sitemap`
- there is a new `data_format` specific for sitemap

Generated file sample can be found here
http://ferbass.xyz/sitemap.xml

Sitemap fileformat ref:
https://www.sitemaps.org/protocol.html

Thank you


