### PR TITLE
clean regeneration of entry files

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -1040,6 +1040,9 @@ rebuild_all_entries() {
         title=$(get_post_title "$i")
 
         get_html_file_content 'text' 'text' <"$i" >> "$contentfile"
+	
+	# delete the last newline character at the end of content to keep the rebuilt version clean
+	truncate -s $(($(stat -c '%s' $contentfile)-1)) "$contentfile"
 
         # Read timestamp from post, if present, and sync file timestamp
         timestamp=$(awk '/<!-- '$date_inpost': .+ -->/ { print }' "$i" | cut -d '#' -f 2)


### PR DESCRIPTION
on all rebuild run the `main()` function calls `rebuild_all_entries()`, within which a call to `get_html_file_content()` is made, and then using the returned information along with timestamp found in the entry a call to `create_html_page()` is made.

but the definition of `create_html_page()` contains the line `echo -e '\n<!-- text end -->'`. the newline character causes all the mess in the rebuilt entries. this happens because newline character gets multiplied in the process of regeneration, and that happens because the function `get_html_file_content()` returns all the lines between `'<!-- $1 begin -->'` and `'<!-- $2 end -->'`, where the variables are either "entry" or "text". but this "content" includes the newline character that was inserted (which was necessary) in the first call to `create_html_page()`, and then because `rebuild_all_entries()` calls it again, on each such call an another newline character is added.

instead of adding (on which i haven't given much thought though) conditional statement in `create_html_page()`, the solution i have given is to just truncate the newline character from the returned string of `get_html_file_content()` to keep the "content" invariant under all these callings.

(this is my first open source commit, i apologize for explaining in boring details. btw, BashBlog is beautiful, thank you!)