### PR TITLE
clickable link of the preview link

### DIFF
--- a/bb.sh
+++ b/bb.sh
@@ -617,7 +617,7 @@ EOF
 
         chmod 644 "$filename"
         [[ -n $preview_url ]] || preview_url=$global_url
-        echo "To preview the entry, open $preview_url/$filename in your browser"
+        echo "To preview the entry, open http://$preview_url/$filename in your browser"
 
         echo -n "[P]ost this entry, [E]dit again, [D]raft for later? (p/E/d) "
         read -r post_status


### PR DESCRIPTION
I mean it's just a small fix. $preview_url/$filename -> http://$preview_url/$filename makes it clickable on the terminal.